### PR TITLE
Subclass webview to override `canPerformAction`

### DIFF
--- a/ios/MJRWebView.h
+++ b/ios/MJRWebView.h
@@ -1,0 +1,13 @@
+//
+//  MJRWebView.h
+//  React-Native-Webview-Bridge
+//
+//  Created by nagender singh shekhawat on 03/02/18.
+//  Copyright © 2018 mojoreads.com. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface MJRWebView : UIWebView
+
+@end

--- a/ios/MJRWebView.m
+++ b/ios/MJRWebView.m
@@ -1,0 +1,17 @@
+//
+//  MJRWebView.m
+//  React-Native-Webview-Bridge
+//
+//  Created by nagender singh shekhawat on 03/02/18.
+//  Copyright © 2018 mojoreads.com. All rights reserved.
+//
+
+#import "MJRWebView.h"
+
+@implementation MJRWebView
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+  // Disable every option here, let RCTWebViewBridge handle everything
+  return NO;
+}
+@end

--- a/ios/RCTWebViewBridge.m
+++ b/ios/RCTWebViewBridge.m
@@ -11,7 +11,7 @@
  */
 
  #import "RCTWebViewBridge.h"
-
+ #import "MJRWebView.h"
  #import <UIKit/UIKit.h>
 
  #import <React/RCTAutoInsetsProtocol.h>
@@ -55,7 +55,7 @@ NSString *const RCTWebViewBridgeSchema = @"wvb";
 
 @implementation RCTWebViewBridge
 {
-    UIWebView *_webView;
+    MJRWebView *_webView;
     NSString *_injectedJavaScript;
 }
 
@@ -65,11 +65,12 @@ NSString *const RCTWebViewBridgeSchema = @"wvb";
         super.backgroundColor = [UIColor clearColor];
         _automaticallyAdjustContentInsets = YES;
         _contentInset = UIEdgeInsetsZero;
-        _webView = [[UIWebView alloc] initWithFrame:self.bounds];
+        _webView = [[MJRWebView alloc] initWithFrame:self.bounds];
 
-        UILongPressGestureRecognizer *tapRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(_handleTap:)];
-        tapRecognizer.delegate = self;
-        [_webView addGestureRecognizer:tapRecognizer];
+        UIMenuItem *commentMenuItem = [[UIMenuItem alloc] initWithTitle:@"Comment" action:@selector(commentAction:)];
+        UIMenuItem *highlightMenuItem = [[UIMenuItem alloc] initWithTitle:@"Highlight" action:@selector(highlightAction:)];
+        [[UIMenuController sharedMenuController] setMenuItems:[NSArray arrayWithObjects:commentMenuItem, highlightMenuItem, /*shareMenuItem,*/ nil]];
+
 
         _webView.delegate = self;
         [self addSubview:_webView];
@@ -80,18 +81,6 @@ NSString *const RCTWebViewBridgeSchema = @"wvb";
 }
 
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
-
-- (void)_handleTap:(UITapGestureRecognizer *)recognizer
-{
-    if (recognizer.state == UIGestureRecognizerStateBegan) {
-        [self becomeFirstResponder];
-        UIMenuItem *commentMenuItem = [[UIMenuItem alloc] initWithTitle:@"Comment" action:@selector(commentAction:)];
-        UIMenuItem *highlightMenuItem = [[UIMenuItem alloc] initWithTitle:@"Highlight" action:@selector(highlightAction:)];
-        // UIMenuItem *shareMenuItem = [[UIMenuItem alloc] initWithTitle:@"Share" action:@selector(shareAction:)];
-
-        [[UIMenuController sharedMenuController] setMenuItems:[NSArray arrayWithObjects:commentMenuItem, highlightMenuItem, /*shareMenuItem,*/ nil]];
-    }
-}
 
 - (void)commentAction:(id)sender {
     NSDictionary<NSString *, id> *event = @{ @"selectionAction": @"comment" };
@@ -122,15 +111,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     }
 
     return [super canPerformAction:action withSender:sender];
-}
-
-- (BOOL)canBecomeFirstResponder {
-    return YES;
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-{
-    return YES;
 }
 
 - (void)goForward

--- a/ios/React-Native-Webview-Bridge.xcodeproj/project.pbxproj
+++ b/ios/React-Native-Webview-Bridge.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C2F869B2025E7820000D0A7 /* MJRWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C2F869A2025E7820000D0A7 /* MJRWebView.m */; };
 		4114DC5C1C187CCB003CD988 /* RCTWebViewBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 4114DC591C187CCB003CD988 /* RCTWebViewBridge.m */; };
 		4114DC5D1C187CCB003CD988 /* RCTWebViewBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4114DC5B1C187CCB003CD988 /* RCTWebViewBridgeManager.m */; };
 /* End PBXBuildFile section */
@@ -24,6 +25,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1C2F86992025E7820000D0A7 /* MJRWebView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MJRWebView.h; sourceTree = SOURCE_ROOT; };
+		1C2F869A2025E7820000D0A7 /* MJRWebView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MJRWebView.m; sourceTree = SOURCE_ROOT; };
 		4114DC4C1C187C3A003CD988 /* libReact-Native-Webview-Bridge.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libReact-Native-Webview-Bridge.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4114DC581C187CCB003CD988 /* RCTWebViewBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTWebViewBridge.h; sourceTree = SOURCE_ROOT; };
 		4114DC591C187CCB003CD988 /* RCTWebViewBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTWebViewBridge.m; sourceTree = SOURCE_ROOT; };
@@ -67,6 +70,8 @@
 				4114DC591C187CCB003CD988 /* RCTWebViewBridge.m */,
 				4114DC5A1C187CCB003CD988 /* RCTWebViewBridgeManager.h */,
 				4114DC5B1C187CCB003CD988 /* RCTWebViewBridgeManager.m */,
+				1C2F86992025E7820000D0A7 /* MJRWebView.h */,
+				1C2F869A2025E7820000D0A7 /* MJRWebView.m */,
 			);
 			path = "React-Native-Webview-Bridge";
 			sourceTree = "<group>";
@@ -138,6 +143,7 @@
 			files = (
 				4114DC5D1C187CCB003CD988 /* RCTWebViewBridgeManager.m in Sources */,
 				4114DC5C1C187CCB003CD988 /* RCTWebViewBridge.m in Sources */,
+				1C2F869B2025E7820000D0A7 /* MJRWebView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/React-Native-Webview-Bridge.xcodeproj/xcuserdata/nagendersingh.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios/React-Native-Webview-Bridge.xcodeproj/xcuserdata/nagendersingh.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>React-Native-Webview-Bridge.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>


### PR DESCRIPTION
This will stop those default `copy`, `cut` and `share` options from coming up. Instead of using a default UIWebview we are subclassing it and overriding `canPerformAction` to return NO. This will make this webview to not add any options to the `UIMenuController` that pops up when a user selects some text. According to the responder chain, everything will then be up to the next view in the hierarchy, in this case, RCTWebViewBridge, where we already have the code to show our custom actions -- `highlight` and `comment`, and nothing else.