### PR TITLE
Override the default double tap gesture recognizer of webview

### DIFF
--- a/ios/RCTWebViewBridgeManager.m
+++ b/ios/RCTWebViewBridgeManager.m
@@ -51,8 +51,7 @@ RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(allowsInlineMediaPlayback, _webView.allowsInlineMediaPlayback, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onBridgeMessage, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelection, RCTBubblingEventBlock)
-
-
+RCT_EXPORT_VIEW_PROPERTY(onDoubleTap, RCTBubblingEventBlock)
 
 - (NSDictionary<NSString *, id> *)constantsToExport
 {

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -108,7 +108,9 @@ var WebViewBridge = createReactClass({
 
     keyboardDisplayRequiresUserAction: PropTypes.bool,
 
-    onSelection: PropTypes.func
+    onSelection: PropTypes.func,
+
+    onDoubleTap: PropTypes.func
   },
 
   getInitialState: function() {


### PR DESCRIPTION
This commit overrides the default behavior for a double tap. We now expose an api `onDoubleTap`, to react-native, which will receive an event with the location of the tap.